### PR TITLE
feat: cache images for a week

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,9 @@
 [build]
   publish = "dist/"
   command = "./deploy.sh"
+
+[[headers]]
+  for = "/images/*"
+  [headers.values]
+    # Cache images for a week
+    cache-control = "public, max-age=604800, must-revalidate"


### PR DESCRIPTION
...since they do not change that often. In case of an urgent change it is imho fine to introduce some kind of versioning in the filename to bust the cache.

FYI: [setting headers on Netlify](https://www.netlify.com/docs/netlify-toml-reference/#headers).

follow-up of #46 